### PR TITLE
Display user details in feed with color highlight for users with >2 repos

### DIFF
--- a/src/app/core/directives/highlight-repos.directive.ts
+++ b/src/app/core/directives/highlight-repos.directive.ts
@@ -1,0 +1,29 @@
+import {
+  Directive,
+  ElementRef,
+  Input,
+  OnChanges,
+  Renderer2,
+  SimpleChanges,
+} from '@angular/core';
+
+@Directive({
+  selector: '[appHighlightRepos]',
+  standalone: true,
+})
+export class HighlightReposDirective implements OnChanges {
+  @Input() appHighlightRepos: number = 0;
+
+  constructor(private el: ElementRef, private renderer: Renderer2) {}
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['appHighlightRepos']) {
+      const value = this.appHighlightRepos;
+      if (value > 2) {
+        this.renderer.setStyle(this.el.nativeElement, 'color', 'red');
+      } else {
+        this.renderer.removeStyle(this.el.nativeElement, 'color');
+      }
+    }
+  }
+}

--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from 'src/environments/environment';
 import { GitHubUserSummary } from 'src/app/store/github/models/github-user-summary.model';
@@ -11,23 +11,29 @@ import { GitHubUserDetail } from 'src/app/store/github/models/github-user-detail
 export class GitHubService {
   private readonly BASE_URL = environment.githubApiBaseUrl;
   private readonly USERS_PER_PAGE = 30;
+  private readonly headers = new HttpHeaders({
+    Authorization: `token ${environment.githubToken}`,
+  });
 
   constructor(private http: HttpClient) {}
 
   /**
    * Get list of GitHub users for feed view
-   * Uses the `since` parameter for pagination
    */
   getUsers(since: number): Observable<GitHubUserSummary[]> {
     return this.http.get<GitHubUserSummary[]>(
-      `${this.BASE_URL}/users?since=${since}&per_page=${this.USERS_PER_PAGE}`
+      `${this.BASE_URL}/users?since=${since}&per_page=${this.USERS_PER_PAGE}`,
+      { headers: this.headers }
     );
   }
 
   /**
-   * Get details of a GitHub user by their username
+   * Get full user details by username
    */
   getUserByUsername(username: string): Observable<GitHubUserDetail> {
-    return this.http.get<GitHubUserDetail>(`${this.BASE_URL}/users/${username}`);
+    return this.http.get<GitHubUserDetail>(
+      `${this.BASE_URL}/users/${username}`,
+      { headers: this.headers }
+    );
   }
 }

--- a/src/app/pages/feed/feed.page.html
+++ b/src/app/pages/feed/feed.page.html
@@ -7,12 +7,12 @@
 <ion-content>
   <div *ngIf="loading$ | async" class="ion-padding">Loading users...</div>
 
-  <ion-list *ngIf="(users$ | async) as users">
+  <ion-list *ngIf="users$ | async as users">
     <ion-item *ngFor="let user of users">
       <ion-avatar slot="start">
         <img [src]="user.avatar_url" />
       </ion-avatar>
-      <ion-label>
+      <ion-label [appHighlightRepos]="user.public_repos">
         {{ user.login }}
       </ion-label>
     </ion-item>
@@ -21,7 +21,8 @@
   <ion-infinite-scroll (ionInfinite)="loadMoreUsers($event)">
     <ion-infinite-scroll-content
       loadingText="Loading more users..."
-      loadingSpinner="dots">
+      loadingSpinner="dots"
+    >
     </ion-infinite-scroll-content>
   </ion-infinite-scroll>
 </ion-content>

--- a/src/app/pages/feed/feed.page.ts
+++ b/src/app/pages/feed/feed.page.ts
@@ -1,7 +1,10 @@
 import { Component, inject } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { CommonModule } from '@angular/common';
-import { githubFeature, GitHubActions } from 'src/app/store/github/github-user.feature';
+import {
+  githubFeature,
+  GitHubActions,
+} from 'src/app/store/github/github-user.feature';
 import {
   IonHeader,
   IonToolbar,
@@ -14,6 +17,7 @@ import {
   IonInfiniteScroll,
   IonInfiniteScrollContent,
 } from '@ionic/angular/standalone';
+import { HighlightReposDirective } from 'src/app/core/directives/highlight-repos.directive'; // ajusta si es necesario
 
 @Component({
   selector: 'app-feed',
@@ -30,6 +34,7 @@ import {
     IonAvatar,
     IonInfiniteScroll,
     IonInfiniteScrollContent,
+    HighlightReposDirective,
   ],
   templateUrl: './feed.page.html',
   styleUrls: ['./feed.page.scss'],
@@ -52,10 +57,15 @@ export class FeedPage {
    * Dispatch next batch of users using the current "since" value
    */
   loadMoreUsers(event: Event) {
-    this.since$.subscribe((since) => {
-      this.store.dispatch(GitHubActions.loadUsers({ since }));
-      // Complete the scroll event after dispatch
-      setTimeout(() => (event.target as HTMLIonInfiniteScrollElement).complete(), 500);
-    }).unsubscribe();
+    this.since$
+      .subscribe((since) => {
+        this.store.dispatch(GitHubActions.loadUsers({ since }));
+        // Complete the scroll event after dispatch
+        setTimeout(
+          () => (event.target as HTMLIonInfiniteScrollElement).complete(),
+          500
+        );
+      })
+      .unsubscribe();
   }
 }

--- a/src/app/store/github/github-user.feature.ts
+++ b/src/app/store/github/github-user.feature.ts
@@ -3,7 +3,7 @@ import { GitHubUserSummary } from './models/github-user-summary.model';
 import { GitHubUserDetail } from './models/github-user-detail.model';
 
 export interface GitHubState {
-  users: GitHubUserSummary[];
+  users: GitHubUserDetail[];
   selectedUser: GitHubUserDetail | null;
   loading: boolean;
   error: string | null;
@@ -22,7 +22,7 @@ export const GitHubActions = createActionGroup({
   source: 'GitHub',
   events: {
     'Load Users': props<{ since: number }>(),
-    'Load Users Success': props<{ users: GitHubUserSummary[] }>(),
+    'Load Users Success': props<{ users: GitHubUserDetail[] }>(),
     'Load Users Failure': props<{ error: string }>(),
 
     'Load User By Username': props<{ username: string }>(),

--- a/src/app/tabs/tabs.page.html
+++ b/src/app/tabs/tabs.page.html
@@ -1,11 +1,11 @@
 <ion-tabs>
   <ion-tab-bar slot="bottom">
-    <ion-tab-button tab="feed" [routerLink]="['/tabs/feed']">
+    <ion-tab-button tab="feed" [routerLink]="['/feed']">
       <ion-icon name="people-outline" aria-hidden="true"></ion-icon>
       <ion-label>Feed</ion-label>
     </ion-tab-button>
 
-    <ion-tab-button tab="user-search" [routerLink]="['/tabs/user-search']">
+    <ion-tab-button tab="user-search" [routerLink]="['/user-search']">
       <ion-icon name="search-outline" aria-hidden="true"></ion-icon>
       <ion-label>Search</ion-label>
     </ion-tab-button>

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: false,
   githubApiBaseUrl: 'https://api.github.com',
+  githubToken: 'YOUR_GITHUB_PERSONAL_ACCESS_TOKEN'
 };


### PR DESCRIPTION
## ✅ Summary

Enhanced the Feed tab to support full GitHub user details.

- Integrated authenticated GitHub API requests using a personal access token (via `environment.ts`)
- Replaced `GitHubUserSummary[]` with full `GitHubUserDetail[]` model in store
- Refactored `GitHubService` to include headers in requests
- Updated `GitHubUserEffects` to fetch full details via `Promise.all`
- Applied `highlightRepos` directive to style users with more than 2 public repositories
- Cleaned up HTML and added directive usage to `<ion-label>`