### PR TITLE
Enable navigation from feed and reactive user lookup with search bar

### DIFF
--- a/src/app/pages/feed/feed.page.html
+++ b/src/app/pages/feed/feed.page.html
@@ -8,7 +8,7 @@
   <div *ngIf="loading$ | async" class="ion-padding">Loading users...</div>
 
   <ion-list *ngIf="users$ | async as users">
-    <ion-item *ngFor="let user of users">
+    <ion-item *ngFor="let user of users" (click)="goToUserSearch(user.login)">
       <ion-avatar slot="start">
         <img [src]="user.avatar_url" />
       </ion-avatar>

--- a/src/app/pages/feed/feed.page.ts
+++ b/src/app/pages/feed/feed.page.ts
@@ -18,6 +18,7 @@ import {
   IonInfiniteScrollContent,
 } from '@ionic/angular/standalone';
 import { HighlightReposDirective } from 'src/app/core/directives/highlight-repos.directive'; // ajusta si es necesario
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-feed',
@@ -41,6 +42,7 @@ import { HighlightReposDirective } from 'src/app/core/directives/highlight-repos
 })
 export class FeedPage {
   private store = inject(Store);
+  private router = inject(Router);
 
   users$ = this.store.select(githubFeature.selectUsers);
   loading$ = this.store.select(githubFeature.selectLoading);
@@ -67,5 +69,13 @@ export class FeedPage {
         );
       })
       .unsubscribe();
+  }
+  /**
+   * Navigate to the User Search tab with the login prefilled
+   */
+  goToUserSearch(username: string) {
+    this.router.navigate(['/user-search'], {
+      queryParams: { username },
+    });
   }
 }

--- a/src/app/pages/user-search/user-search.page.html
+++ b/src/app/pages/user-search/user-search.page.html
@@ -1,13 +1,89 @@
-<ion-header [translucent]="true">
+<ion-header>
   <ion-toolbar>
-    <ion-title>user-search</ion-title>
+    <ion-title>GitHub User</ion-title>
+  </ion-toolbar>
+  <ion-toolbar>
+    <ion-searchbar
+      [(ngModel)]="searchTerm"
+      (ionInput)="onSearch()"
+      debounce="400"
+      placeholder="Search GitHub username"
+    ></ion-searchbar>
   </ion-toolbar>
 </ion-header>
 
-<ion-content [fullscreen]="true">
-  <ion-header collapse="condense">
-    <ion-toolbar>
-      <ion-title size="large">user-search</ion-title>
-    </ion-toolbar>
-  </ion-header>
+<ion-content class="ion-padding">
+  <div *ngIf="loading$ | async" class="ion-text-center">
+    <ion-spinner name="dots"></ion-spinner>
+    <p>Loading user...</p>
+  </div>
+
+  <div *ngIf="error$ | async as error" class="ion-text-center">
+    <p class="ion-text-danger">❌ {{ error }}</p>
+  </div>
+
+  <ng-container *ngIf="user$ | async as user">
+    <ion-card>
+      <ion-card-header class="ion-text-center">
+        <ion-avatar class="ion-margin-auto" style="width: 96px; height: 96px">
+          <img [src]="user.avatar_url" alt="User Avatar" />
+        </ion-avatar>
+        <ion-card-title class="ion-padding-top">
+          {{ user.name || user.login }}
+        </ion-card-title>
+        <ion-card-subtitle>{{ user.login }}</ion-card-subtitle>
+      </ion-card-header>
+
+      <ion-card-content>
+        <ion-list>
+          <ion-item *ngIf="user.bio">
+            <ion-label>
+              <strong>Bio:</strong><br />
+              {{ user.bio }}
+            </ion-label>
+          </ion-item>
+
+          <ion-item *ngIf="user.company">
+            <ion-label>
+              <strong>Company:</strong> {{ user.company }}
+            </ion-label>
+          </ion-item>
+
+          <ion-item *ngIf="user.location">
+            <ion-label>
+              <strong>Location:</strong> {{ user.location }}
+            </ion-label>
+          </ion-item>
+
+          <ion-item *ngIf="user.public_repos !== null">
+            <ion-label>
+              <strong>Public Repos:</strong> {{ user.public_repos }}
+            </ion-label>
+          </ion-item>
+
+          <ion-item *ngIf="user.followers !== null">
+            <ion-label>
+              <strong>Followers:</strong> {{ user.followers }}
+            </ion-label>
+          </ion-item>
+
+          <ion-item *ngIf="user.blog">
+            <ion-label>
+              <strong>Blog:</strong><br />
+              {{ user.blog }}
+            </ion-label>
+          </ion-item>
+        </ion-list>
+
+        <ion-button
+          *ngIf="user.blog"
+          expand="block"
+          fill="outline"
+          (click)="openBlog(user.blog)"
+        >
+          🔗 Open Blog
+        </ion-button>
+      </ion-card-content>
+    </ion-card>
+  </ng-container>
 </ion-content>

--- a/src/app/pages/user-search/user-search.page.ts
+++ b/src/app/pages/user-search/user-search.page.ts
@@ -1,20 +1,99 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, inject, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { ViewWillEnter } from '@ionic/angular';
+import {
+  IonContent,
+  IonHeader,
+  IonTitle,
+  IonToolbar,
+  IonAvatar,
+  IonButton,
+  IonCard,
+  IonCardHeader,
+  IonCardTitle,
+  IonCardSubtitle,
+  IonCardContent,
+  IonList,
+  IonItem,
+  IonLabel,
+  IonSpinner,
+  IonSearchbar,
+} from '@ionic/angular/standalone';
+import { ActivatedRoute } from '@angular/router';
+import { Store } from '@ngrx/store';
+import {
+  GitHubActions,
+  githubFeature,
+} from 'src/app/store/github/github-user.feature';
 import { FormsModule } from '@angular/forms';
-import { IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-user-search',
   templateUrl: './user-search.page.html',
   styleUrls: ['./user-search.page.scss'],
   standalone: true,
-  imports: [IonContent, IonHeader, IonTitle, IonToolbar, CommonModule, FormsModule]
+  imports: [
+    CommonModule,
+    FormsModule,
+    IonContent,
+    IonHeader,
+    IonTitle,
+    IonToolbar,
+    IonAvatar,
+    IonButton,
+    IonCard,
+    IonCardHeader,
+    IonCardTitle,
+    IonCardSubtitle,
+    IonCardContent,
+    IonList,
+    IonItem,
+    IonLabel,
+    IonSpinner,
+    IonSearchbar,
+  ],
 })
-export class UserSearchPage implements OnInit {
+export class UserSearchPage implements ViewWillEnter {
+  private route = inject(ActivatedRoute);
+  private store = inject(Store);
 
-  constructor() { }
+  user$ = this.store.select(githubFeature.selectSelectedUser);
+  loading$ = this.store.select(githubFeature.selectLoading);
+  error$ = this.store.select(githubFeature.selectError);
 
-  ngOnInit() {
+  searchTerm = '';
+
+  ionViewWillEnter() {
+    this.route.queryParams.subscribe((params) => {
+      const username = params['username'];
+      if (username) {
+        this.searchTerm = username;
+        this.store.dispatch(
+          GitHubActions.loadUserByUsername({ username: username })
+        );
+      } else {
+        this.searchTerm = '';
+        this.store.dispatch(GitHubActions.clearSelectedUser());
+      }
+    });
   }
 
+  /**
+   * Trigger GitHub user search using the value from the search bar.
+   */
+  onSearch() {
+    const trimmed = this.searchTerm.trim();
+    if (trimmed.length > 0) {
+      this.store.dispatch(
+        GitHubActions.loadUserByUsername({ username: trimmed })
+      );
+    }
+  }
+
+  /**
+   * Open blog URL in new tab
+   */
+  openBlog(url: string) {
+    window.open(url.startsWith('http') ? url : `https://${url}`, '_blank');
+  }
 }

--- a/src/app/store/github/github-user.feature.ts
+++ b/src/app/store/github/github-user.feature.ts
@@ -1,4 +1,12 @@
-import { createFeature, createReducer, on, createSelector, createActionGroup, props } from '@ngrx/store';
+import {
+  createFeature,
+  createReducer,
+  on,
+  createSelector,
+  createActionGroup,
+  props,
+  emptyProps,
+} from '@ngrx/store';
 import { GitHubUserSummary } from './models/github-user-summary.model';
 import { GitHubUserDetail } from './models/github-user-detail.model';
 
@@ -28,6 +36,7 @@ export const GitHubActions = createActionGroup({
     'Load User By Username': props<{ username: string }>(),
     'Load User By Username Success': props<{ user: GitHubUserDetail }>(),
     'Load User By Username Failure': props<{ error: string }>(),
+    'Clear Selected User': emptyProps(),
   },
 });
 
@@ -71,6 +80,11 @@ export const githubFeature = createFeature({
       ...state,
       loading: false,
       error,
+    })),
+
+    on(GitHubActions.clearSelectedUser, (state) => ({
+      ...state,
+      selectedUser: null,
     }))
   ),
 


### PR DESCRIPTION
## ✅ Summary

Implemented the User Search tab with full detail view.

- Enabled navigation to `/user-search` with `username` query param
- Integrated `ion-searchbar` for GitHub login search
- Reset state on tab switch using `clearSelectedUser` action
- Leveraged `ionViewWillEnter` to handle lifecycle correctly
- Displayed user details using styled `ion-card` layout
- Improved UX with `ion-spinner` for loading and error handling
